### PR TITLE
Docker build: uprev gosu version to support mac m1 processor

### DIFF
--- a/docker/midas-portal/Dockerfile
+++ b/docker/midas-portal/Dockerfile
@@ -29,7 +29,7 @@ RUN cd /usr/local && tar xJf /tmp/node-v16.17.1-linux-x64.tar.xz \
                   && ln -s ../node/bin/npm  npm                 \
                   && ln -s ../node/bin/npx  npx            
 
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION 1.14
 RUN set -ex; \
     arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
     wget -O /usr/local/bin/gosu \


### PR DESCRIPTION
To enable docker-based builds of the dmp tool on modern Macs featuring the m1 processor, it is necessary to use a more recent version of the gosu tool.

This branch is simply a rebase of the [testgosu branch](https://github.com/usnistgov/oar-midas-portal/commits/testgosu) (against main) provided by @Iskander54.

To test, simply,

1. checkout this branch
2. run `scripts/makedist.docker`, and 
3. ensure that the product builds properly and is archived into the `dist` directory as a zip file; make sure the files are owned by you (the tester).