### PR TITLE
 dependabot

### DIFF
--- a/midas-portal/package.json
+++ b/midas-portal/package.json
@@ -28,7 +28,6 @@
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.11.4"
-       
     },
     "optionalDependencies": {
         "oarng": "file:../lib/dist/oarng"
@@ -48,7 +47,7 @@
         "@typescript-eslint/parser": "5.27.1",
         "eslint": "^8.17.0",
         "jasmine-core": "~4.0.0",
-        "karma": "~6.3.0",
+        "karma": "~6.3.16",
         "karma-chrome-launcher": "~3.1.0",
         "karma-coverage": "~2.1.0",
         "karma-jasmine": "~4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
                 "@typescript-eslint/parser": "5.27.1",
                 "eslint": "^8.17.0",
                 "jasmine-core": "~4.0.0",
-                "karma": "~6.3.0",
+                "karma": "~6.3.16",
                 "karma-chrome-launcher": "~3.1.0",
                 "karma-coverage": "~2.1.0",
                 "karma-jasmine": "~4.0.0",
@@ -6944,7 +6944,7 @@
             "dev": true
         },
         "node_modules/decode-uri-component": {
-            "version": "0.2.0",
+            "version": "0.2.2",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8866,7 +8866,7 @@
             "license": "MIT"
         },
         "node_modules/http-cache-semantics": {
-            "version": "4.1.0",
+            "version": "4.1.1",
             "dev": true,
             "license": "BSD-2-Clause"
         },
@@ -15713,7 +15713,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "duplexer": "^0.1.1",
-                "minimist": "^1.2.0",
+                "minimist": "^1.2.6",
                 "through": "^2.3.4"
             },
             "bin": {
@@ -16122,7 +16122,7 @@
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "minimist": "^1.2.0"
+                "minimist": "^1.2.6"
             },
             "bin": {
                 "json5": "lib/cli.js"
@@ -16212,7 +16212,7 @@
             }
         },
         "node_modules/ua-parser-js": {
-            "version": "0.7.32",
+            "version": "0.7.33",
             "dev": true,
             "funding": [
                 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,7 +223,7 @@
                 "text-table": "0.2.0",
                 "tree-kill": "1.2.2",
                 "tslib": "2.3.1",
-                "webpack": "5.70.0",
+                "webpack": "5.76.0",
                 "webpack-dev-middleware": "5.3.0",
                 "webpack-dev-server": "4.7.3",
                 "webpack-merge": "5.8.0",
@@ -303,7 +303,7 @@
                 "yarn": ">= 1.13.0"
             },
             "peerDependencies": {
-                "webpack": "^5.30.0",
+                "webpack": ">=5.76.0",
                 "webpack-dev-server": "^4.0.0"
             }
         },
@@ -3619,7 +3619,7 @@
             "peerDependencies": {
                 "@angular/compiler-cli": "^13.0.0",
                 "typescript": ">=4.4.3 <4.7",
-                "webpack": "^5.30.0"
+                "webpack": ">=5.76.0"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -5622,7 +5622,7 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0",
-                "webpack": ">=2"
+                "webpack": ">=5.76.0"
             }
         },
         "node_modules/babel-loader/node_modules/loader-utils": {
@@ -6173,7 +6173,7 @@
                 "node": ">=6.0.0"
             },
             "peerDependencies": {
-                "webpack": ">=4.0.1"
+                "webpack": ">=5.76.0"
             }
         },
         "node_modules/cjs-module-lexer": {
@@ -6492,7 +6492,7 @@
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^5.1.0"
+                "webpack": ">=5.76.0"
             }
         },
         "node_modules/copy-webpack-plugin/node_modules/array-union": {
@@ -6794,7 +6794,7 @@
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^5.0.0"
+                "webpack": ">=5.76.0"
             }
         },
         "node_modules/css-prefers-color-scheme": {
@@ -11502,7 +11502,7 @@
                 "parse5": "^7.1.1",
                 "saxes": "^6.0.0",
                 "symbol-tree": "^3.2.4",
-                "tough-cookie": "^4.1.2",
+                "tough-cookie": ">=4.1.3",
                 "w3c-xmlserializer": "^4.0.0",
                 "webidl-conversions": "^7.0.0",
                 "whatwg-encoding": "^2.0.0",
@@ -11930,7 +11930,7 @@
             },
             "peerDependencies": {
                 "less": "^3.5.0 || ^4.0.0",
-                "webpack": "^5.0.0"
+                "webpack": ">=5.76.0"
             }
         },
         "node_modules/less/node_modules/make-dir": {
@@ -12377,7 +12377,7 @@
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^5.0.0"
+                "webpack": ">=5.76.0"
             }
         },
         "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
@@ -14001,7 +14001,7 @@
             },
             "peerDependencies": {
                 "postcss": "^7.0.0 || ^8.0.1",
-                "webpack": "^5.0.0"
+                "webpack": ">=5.76.0"
             }
         },
         "node_modules/postcss-logical": {
@@ -15026,7 +15026,7 @@
                 "fibers": ">= 3.1.0",
                 "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
                 "sass": "^1.3.0",
-                "webpack": "^5.0.0"
+                "webpack": ">=5.76.0"
             },
             "peerDependenciesMeta": {
                 "fibers": {
@@ -15367,7 +15367,7 @@
                 "debug": "~4.3.2",
                 "engine.io": "~6.2.1",
                 "socket.io-adapter": "~2.4.0",
-                "socket.io-parser": "~4.2.1"
+                "socket.io-parser": ">=4.2.3"
             },
             "engines": {
                 "node": ">=10.0.0"
@@ -15379,7 +15379,7 @@
             "license": "MIT"
         },
         "node_modules/socket.io-parser": {
-            "version": "4.2.1",
+            "version": "4.2.3",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15459,7 +15459,7 @@
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^5.0.0"
+                "webpack": ">=5.76.0"
             }
         },
         "node_modules/source-map-loader/node_modules/iconv-lite": {
@@ -15479,7 +15479,7 @@
             "license": "MIT",
             "dependencies": {
                 "atob": "^2.1.2",
-                "decode-uri-component": "^0.2.0"
+                "decode-uri-component": ">=0.2.1"
             }
         },
         "node_modules/source-map-support": {
@@ -15760,7 +15760,7 @@
             },
             "peerDependencies": {
                 "stylus": ">=0.52.4",
-                "webpack": "^5.0.0"
+                "webpack": ">=5.76.0"
             }
         },
         "node_modules/supports-color": {
@@ -15874,7 +15874,7 @@
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^5.1.0"
+                "webpack": ">=5.76.0"
             },
             "peerDependenciesMeta": {
                 "@swc/core": {
@@ -16112,7 +16112,7 @@
             "license": "MIT",
             "dependencies": {
                 "@types/json5": "^0.0.29",
-                "json5": "^1.0.1",
+                "json5": "^2.1.2",
                 "minimist": "^1.2.6",
                 "strip-bom": "^3.0.0"
             }
@@ -16510,7 +16510,7 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.70.0",
+            "version": "5.76.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16574,7 +16574,7 @@
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^4.0.0 || ^5.0.0"
+                "webpack": ">=5.76.0"
             }
         },
         "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
@@ -16637,7 +16637,7 @@
                 "node": ">= 12.13.0"
             },
             "peerDependencies": {
-                "webpack": "^4.37.0 || ^5.0.0"
+                "webpack": ">=5.76.0"
             },
             "peerDependenciesMeta": {
                 "webpack-cli": {
@@ -16720,7 +16720,7 @@
             },
             "peerDependencies": {
                 "html-webpack-plugin": ">= 5.0.0-beta.1 < 6",
-                "webpack": "^5.12.0"
+                "webpack": ">=5.76.0"
             },
             "peerDependenciesMeta": {
                 "html-webpack-plugin": {


### PR DESCRIPTION
If this branch is updated, I @Iskander54  will delete all the dependabot PR made before that PR.

You can find below the details of the changes made, checking each and every dependabot PR requested by github. 



Bump karma from 6.3.15 to 6.3.16 in /midas-portal #1
midas-portal/package.json updated to 6.3.16
midas-portal/package-lock.json doesn’t exist anymore, update the package-lock.json 
in root folder instead

Bump node-forge from 1.2.1 to 1.3.0 in /midas-portal #3
midas-portal/package.json no updated required
midas-portal/package-lock.json doesn’t exist anymore,./package-lock.json 
is already 1.3.1

Bump minimist from 1.2.5 to 1.2.6 in /midas-portal #6
midas-portal/package.json no updated required
midas-portal/package-lock.json doesn’t exist anymore,./package-lock.json 
is already 1.2.7

Bump async from 2.6.3 to 2.6.4 in /midas-portal #7
midas-portal/package.json no updated required
midas-portal/package-lock.json doesn’t exist anymore,./package-lock.json 
is already 3.2.4

Bump socket.io-parser from 4.0.4 to 4.0.5 in /midas-portal #9
midas-portal/package.json no updated required
midas-portal/package-lock.json doesn’t exist anymore,./package-lock.json 
is already 4.2.1

Bump loader-utils from 1.4.0 to 1.4.2 in /midas-portal #10
midas-portal/package.json no updated required
midas-portal/package-lock.json doesn’t exist anymore,./package-lock.json 
is already 3.2.1

Bump engine.io and socket.io in /midas-portal #11
midas-portal/package.json no updated required
midas-portal/package-lock.json doesn’t exist anymore,./package-lock.json 
is already 6.2.1 engine.io and 4.5.4 socket.io

Bump qs, body-parser and express in /midas-portal #13
midas-portal/package.json no updated required
midas-portal/package-lock.json doesn’t exist anymore,./package-lock.json 
is already 1.20.1 for body-parser, 6.11.0 for sq and 4.18.2 for qs

Bump decode-uri-component from 0.2.0 to 0.2.2 in /midas-portal #14
midas-portal/package.json no updated required
midas-portal/package-lock.json doesn’t exist anymore,./package-lock.json 
has been updated to 0.2.2

Bump express from 4.17.2 to 4.18.2 in /midas-portal #15
midas-portal/package.json no updated required
midas-portal/package-lock.json doesn’t exist anymore,./package-lock.json 
is already 4.18.2


Bump json5 and @angular-devkit/build-angular in /midas-portal #16
midas-portal/package.json no updated required
midas-portal/package-lock.json doesn’t exist anymore,./package-lock.json 
is already 2.2.3 for json5 and 13.3.10 for devkit/build-angular

Bump json5 from 1.0.1 to 1.0.2 in /midas-portal #17
midas-portal/package.json no updated required
I don’t understand that upgrade because json5 is already a higher version in the ./package-lock.json

Bump ua-parser-js from 0.7.31 to 0.7.33 in /midas-portal #18
midas-portal/package.json no updated required
midas-portal/package-lock.json doesn’t exist anymore,./package-lock.json 
has been updated to 0.7.33

Bump http-cache-semantics from 4.1.0 to 4.1.1 in /midas-portal #19
midas-portal/package.json no updated required
midas-portal/package-lock.json doesn’t exist anymore,./package-lock.json 
has been updated to 4.1.0

+ 5 version updates from Security
