### PR TITLE
Support builds within NIST firewall (with further build script cleanup)

### DIFF
--- a/docker/cacerts/README.md
+++ b/docker/cacerts/README.md
@@ -1,0 +1,13 @@
+This directory contains non-standard CA certificates needed to build the docker
+images. 
+
+Failures building the Docker containers defined in ../ due to SSL certificate
+verification errors may be a consequence of your local network's firewall.  In
+particular, the firewall may be substituting external site certificates with
+its own signed by a non-standard CA certficate (chain).  If so, you can place 
+the necessary certificates into this directory; they will be passed into the
+containers, allowing them to safely connect to those external sites.
+
+Be sure the certificates are in PEM format and include a .crt file extension.
+
+Do not remove this README file; doing so may cause a Docker build faiure.

--- a/docker/dockbuild.sh
+++ b/docker/dockbuild.sh
@@ -22,7 +22,7 @@ PACKAGE_NAME=oar-midas-portal
 ## containers to be built.  List them in dependency order (where a latter one
 ## depends the former ones).  
 #
-DOCKER_IMAGE_DIRS="pymongo jqfromsrc ejsonschema midas-portal nps"
+DOCKER_IMAGE_DIRS="midas-portal npsbroker"
 
 . $codedir/oar-build/_dockbuild.sh
 
@@ -37,10 +37,19 @@ setup_build
 
 log_intro   # record start of build into log
 
-# $codedir/oar-metadata/docker/dockbuild.sh $BUILD_IMAGES
+if { echo " $BUILD_IMAGES " | egrep -qs " midas-portal "; }; then
+    # install CA certs into containers that can use them
+    cp_ca_certs_to midas-portal
 
-echo '+' docker build $BUILD_OPTS -t $PACKAGE_NAME/midas-portal midas-portal
-docker build $BUILD_OPTS -t $PACKAGE_NAME/midas-portal midas-portal 2>&1
-#This can be added to the systems which need to build the docker image
-# echo '+' docker build $BUILD_OPTS -t $PACKAGE_NAME/npsbroker npsbroker
-# docker build $BUILD_OPTS -t $PACKAGE_NAME/npsbroker npsbroker 2>&1
+    echo '+' docker build $BUILD_OPTS -t $PACKAGE_NAME/midas-portal midas-portal
+    docker build $BUILD_OPTS -t $PACKAGE_NAME/midas-portal midas-portal 2>&1
+fi
+
+if { echo " $BUILD_IMAGES " | egrep -qs " npsbroker "; }; then
+    # install CA certs into containers that can use them
+    cp_ca_certs_to npsbroker
+
+    echo '+' docker build $BUILD_OPTS -t $PACKAGE_NAME/npsbroker npsbroker
+    docker build $BUILD_OPTS -t $PACKAGE_NAME/npsbroker npsbroker 2>&1
+fi
+

--- a/docker/makedist
+++ b/docker/makedist
@@ -11,12 +11,8 @@
 #   python             build only the python-based distributions
 #   angular            build only the angular-based distributions
 #
-
-
-echo "********************** makdist in docker"
-
 #   midas-portal       build the portal application
-#   midas-nps          build the NPS proxy service
+#   npsbroker          build the NPS proxy service
 #
 
 prog=`basename $0`
@@ -25,18 +21,28 @@ execdir=`dirname $0`
 export CODEDIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
 export DOCKERDIR=$execdir
 
-echo "Creating scripts directory path"
+os=`uname`
+SED_RE_OPT=r
+[ "$os" != "Darwin" ] || SED_RE_OPT=E
+
 #This is a repo level scripts directory
-scriptsdir=$DOCKERDIR/../scripts/
+scriptsdir=$CODEDIR/scripts
 
-if [ $1 = "npsbroker" ]; then 
-    echo "Build python $@"
-    #This builds the python section of the portal code
-    $scriptsdir/makedist.npsbroker
+buildpy=1
+[ $# == "0" ] || buildpy=`echo " $@ " | egrep " npsbroker | python "`
+buildang=1
+[ $# == "0" ] || buildang=`echo " $@ " | egrep " midas-portal | angular "`
+args=`echo " $@ " | sed -${SED_RE_OPT}e 's/ (npsbroker|midas-portal|angular|python) / /g'`
+
+if [ -n "$buildpy" ]; then
+    # No special docker environment is required to build
+    # the npsbroker; we can do it natively
+    echo "Building npsbroker (natively)"
+    $scriptsdir/makedist.npsbroker $args
 fi
-# $scriptsdir/makedist.npsbroker
 
-#run.sh is called to execute dockerized builds for example in this case
-# it is for angular building
-exec $DOCKERDIR/run.sh build "$@"
+if [ -n "$buildang" ]; then
+    echo "Building midas-portal via docker"
+    exec $DOCKERDIR/run.sh build $args angular
+fi
 

--- a/docker/midas-portal/Dockerfile
+++ b/docker/midas-portal/Dockerfile
@@ -17,7 +17,8 @@ RUN sed -e '/bullseye-updates/ s/^deb/#deb/' /etc/apt/sources.list \
     > /tmp/sources.list && mv /tmp/sources.list /etc/apt/sources.list
 RUN apt-get update && \
     apt-get install -y --no-install-recommends zip wget ca-certificates git \
-                                               xz-utils gnupg python3
+                                               xz-utils gnupg python3 \
+                                               build-essential
 
 COPY cacerts/README.md cacerts/*.crt /usr/local/share/ca-certificates/
 RUN update-ca-certificates

--- a/docker/midas-portal/Dockerfile
+++ b/docker/midas-portal/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
 
 COPY cacerts/README.md cacerts/*.crt /usr/local/share/ca-certificates/
 RUN update-ca-certificates
+ENV NODE_EXTRA_CA_CERTS /etc/ssl/certs/ca-certificates.crt
 
 ENV GOSU_VERSION 1.14
 RUN set -ex; \

--- a/docker/midas-portal/Dockerfile
+++ b/docker/midas-portal/Dockerfile
@@ -16,8 +16,8 @@ FROM node:16.17-bullseye-slim
 RUN sed -e '/bullseye-updates/ s/^deb/#deb/' /etc/apt/sources.list \
     > /tmp/sources.list && mv /tmp/sources.list /etc/apt/sources.list
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends zip wget ca-certificates git xz-utils \
-                                               gnupg python3
+    apt-get install -y --no-install-recommends zip wget ca-certificates git \
+                                               xz-utils gnupg python3
 
 ENV GOSU_VERSION 1.14
 RUN set -ex; \

--- a/docker/midas-portal/Dockerfile
+++ b/docker/midas-portal/Dockerfile
@@ -19,6 +19,9 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends zip wget ca-certificates git \
                                                xz-utils gnupg python3
 
+COPY cacerts/README.md cacerts/*.crt /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 ENV GOSU_VERSION 1.14
 RUN set -ex; \
     arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \

--- a/docker/midas-portal/cacerts/README.md
+++ b/docker/midas-portal/cacerts/README.md
@@ -1,0 +1,13 @@
+This directory contains non-standard CA certificates needed to build the docker
+images. 
+
+Failures building the Docker containers defined in ../ due to SSL certificate
+verification errors may be a consequence of your local network's firewall.  In
+particular, the firewall may be substituting external site certificates with
+its own signed by a non-standard CA certficate (chain).  If so, you can place 
+the necessary certificates into this directory; they will be passed into the
+containers, allowing them to safely connect to those external sites.
+
+Be sure the certificates are in PEM format and include a .crt file extension.
+
+Do not remove this README file; doing so may cause a Docker build faiure.

--- a/docker/npsbroker/Dockerfile
+++ b/docker/npsbroker/Dockerfile
@@ -1,9 +1,18 @@
-FROM oar-metadata/ejsonschema
+FROM python:3.8-bookworm
 
-RUN apt-get update && apt-get install -y python-yaml curl wget less sudo zip \
-                                         p7zip-full ca-certificates git
-# RUN pip install --upgrade pip setuptools
-RUN pip install funcsigs 'bagit>=1.6.3,<2.0' 'fs>=2.0.21' jsonpatch mako
+RUN apt-get update && apt-get install -y curl wget less sudo git zip unzip   \
+                                         p7zip-full ca-certificates uuid-dev \
+                                         build-essential python3-distutils   \
+                                         libcap-dev libpcre3-dev \
+                                         uwsgi uwsgi-src 
+RUN uwsgi --build-plugin "/usr/src/uwsgi/plugins/python python" && \
+    mv python_plugin.so /usr/lib/uwsgi/plugins/python_plugin.so && \
+    chmod 644 /usr/lib/uwsgi/plugins/python_plugin.so
+                                         
+COPY cacerts/README.md cacerts/*.crt /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
+RUN pip install -U flask flask-restful flask-cors pyopenssl 
 
 RUN sed --in-place -e '/CREATE_MAIL_SPOOL/ s/=yes/=no/' /etc/default/useradd
 ARG devuser=developer

--- a/docker/npsbroker/Dockerfile
+++ b/docker/npsbroker/Dockerfile
@@ -11,6 +11,7 @@ RUN uwsgi --build-plugin "/usr/src/uwsgi/plugins/python python" && \
                                          
 COPY cacerts/README.md cacerts/*.crt /usr/local/share/ca-certificates/
 RUN update-ca-certificates
+ENV REQUESTS_CA_BUNDLE
 
 RUN pip install -U flask flask-restful flask-cors pyopenssl 
 

--- a/docker/npsbroker/cacerts/README.md
+++ b/docker/npsbroker/cacerts/README.md
@@ -1,0 +1,13 @@
+This directory contains non-standard CA certificates needed to build the docker
+images. 
+
+Failures building the Docker containers defined in ../ due to SSL certificate
+verification errors may be a consequence of your local network's firewall.  In
+particular, the firewall may be substituting external site certificates with
+its own signed by a non-standard CA certficate (chain).  If so, you can place 
+the necessary certificates into this directory; they will be passed into the
+containers, allowing them to safely connect to those external sites.
+
+Be sure the certificates are in PEM format and include a .crt file extension.
+
+Do not remove this README file; doing so may cause a Docker build faiure.

--- a/docker/npsbroker/entrypoint.sh
+++ b/docker/npsbroker/entrypoint.sh
@@ -4,20 +4,10 @@ port=9092
 script=/dev/oar-midas-portal/python/nps_server/nps_broker.py
 [ -f "$script" ] || script=/app/dist/npsbroker/bin/nps_broker.py
 
-[ -n "$OAR_WORKING_DIR" ] || OAR_WORKING_DIR=`mktemp --tmpdir -d _npserver.XXXXX`
-[ -d "$OAR_WORKING_DIR" ] || {
-    echo npsserver: ${OAR_WORKING_DIR}: working directory does not exist
-    exit 10
-}
-[ -n "$OAR_LOG_DIR" ] || export OAR_LOG_DIR=$OAR_WORKING_DIR
-
 echo
-echo Working Dir: $OAR_WORKING_DIR
-echo Access the MIDAS web services at http://localhost:$port/
+echo Access the NPS Broker service at http://localhost:$port/
 echo
 
+echo '++' uwsgi --plugin python --http-socket :$port --wsgi-file $script 
+uwsgi --plugin python --http-socket :$port --wsgi-file $script
 
-echo '++' uwsgi --plugin python3 --http-socket :$port --wsgi-file $script  \
-                --set-ph oar_working_dir=$OAR_WORKING_DIR $opts
-uwsgi --plugin python3 --http-socket :$port --wsgi-file $script --static-map /docs=/docs \
-      --set-ph oar_working_dir=$OAR_WORKING_DIR $opts

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -182,7 +182,7 @@ fi
 #
 if wordin shell $cmds; then
     echo '+' docker run -ti --rm $volopt "${dargs[@]}"  \
-                    oar-pdr-angular/build-test shell "${args[@]}"
+                    oar-pdr-angular/midas-portal shell "${args[@]}"
     docker run --rm -ti $volopt "${dargs[@]}" \
            oar-midas-portal/midas-portal shell
 fi

--- a/oar-build/_dockbuild.sh
+++ b/oar-build/_dockbuild.sh
@@ -60,6 +60,21 @@ function setup_build {
     BUILD_OPTS=`collect_build_opts`
 }
 
+function cp_ca_certs_to {
+    # assuming we are in the docker dir
+    [ \! -d cacerts ] || {
+        crts=`compgen -G 'cacerts/*.crt' || true`
+        [ -z "$crts" ] || {
+            echo "${prog}: installing CA certs from docker/cacerts"
+            for cont in $@; do
+                mkdir -p $cont/cacerts
+                echo '+' cp $crts cacerts/README.md $cont/cacerts
+                cp $crts cacerts/README.md $cont/cacerts
+            done
+        }
+    }
+}
+
 function help {
     helpfile=$OAR_BUILD_DIR/dockbuild_help.txt
     [ -f "$OAR_DOCKER_DIR/dockbuild_help.txt" ] && \

--- a/scripts/install_ca_certs.sh
+++ b/scripts/install_ca_certs.sh
@@ -1,0 +1,37 @@
+#! /bin/bash
+#
+# install_ca_certs.sh -- copy the specified CA certificates into this source so that they can be used
+#                        to build the software via docker.
+#
+# usage: install_ca_certs.sh CA_CERT_FILE...
+#
+#   where CA_CERT_FILE is a file path to a CA certificate to install
+#
+# This script helps address the problem with docker-based builds when run within a firewall that
+# replaces external site certificates with ones signed by a non-standard CA, causing the retrieval
+# of software dependencies to fail.  This script is used by oar-docker's localbuild script to receive 
+# extra CA certificates that addresses such failures.  Because localdeploy makes no assumptions about 
+# how this source code repository builds using docker, this script encapsulates that knowledge on 
+# behalf of localbuild.
+#
+# Note: if this repository does not require/support use of non-standard CA certificates, remove (or
+# rename) this script.
+#
+set -e
+prog=`basename $0`
+execdir=`dirname $0`
+[ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
+basedir=`dirname $execdir`
+
+cacertdir="$basedir/docker/cacerts"
+[ -d "$cacertdir" ] || exit 0         # I guess we don't need the certs
+
+crts=`echo $@ | sed -e 's/^ *//' -e 's/ *$//'`
+[ -n "$crts" ] || {
+    print "${prog}: Missing cert file argument"
+    false
+}
+
+echo '+' cp $crts $cacertdir
+cp $crts $cacertdir
+

--- a/scripts/makedist.docker
+++ b/scripts/makedist.docker
@@ -22,5 +22,4 @@ export DOCKERDIR=$CODEDIR/docker
 $DOCKERDIR/dockbuild.sh
 
 # Run the main makedist in the dockerdir
-echo "Run makedist for oar-midas-portal"
 exec $DOCKERDIR/makedist "$@"

--- a/scripts/makedist.docker
+++ b/scripts/makedist.docker
@@ -19,7 +19,7 @@ execdir=`dirname $0`
 export CODEDIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
 export DOCKERDIR=$CODEDIR/docker
 
-$DOCKERDIR/dockbuild.sh
+$DOCKERDIR/dockbuild.sh midas-portal
 
 # Run the main makedist in the dockerdir
 exec $DOCKERDIR/makedist "$@"

--- a/scripts/makedist.npsbroker
+++ b/scripts/makedist.npsbroker
@@ -19,7 +19,7 @@
 #                             products into.
 #    -d DIR, --source-dir=DIR  the directory containing the python source code
 #                             (default: ./python)
-#    -c DIR, --cache-dir=DIR  directory for holding intermediate or cache-able
+#    --dist-dir=DIR           directory for holding intermediate or cache-able
 #                             products (currently not used); this can be shared
 #                             with other similar packages to avoid redundant 
 #                             re-building.
@@ -53,17 +53,13 @@ SOURCE_DIR=$PACKAGE_DIR/python
 DIST_DIR=$PACKAGE_DIR/dist
 BUILD_DIR=$SOURCE_DIR/dist
 VERSION=
-
-
-# Update this list with the names of the individual component names
-# 
-DISTNAMES=(npsbroker)
+DISTNAME=npsbroker
 
 # handle command line options
 while [ "$1" != "" ]; do 
   case "$1" in
     --list|-l)
-        echo "Available distributions: $DISTNAMES"
+        echo "Available distributions: $DISTNAME"
         exit 0
         ;;
     --dist-dir=*)
@@ -79,15 +75,6 @@ while [ "$1" != "" ]; do
     -d|--dir|--source-dir)
         shift
         SOURCE_DIR=$1
-        ;;
-    --cache-dir=*)
-        CACHE_DIR=`echo $1 | sed -e 's/[^=]*=//'`
-        # NOTE: CACHE_DIR is ignored
-        ;;
-    -c|--cache-dir)
-        shift
-        CACHE_DIR=$1
-        # NOTE: CACHE_DIR is ignored
         ;;
     -v|--version)
         shift
@@ -113,14 +100,8 @@ while [ "$1" != "" ]; do
 done
 
 true ${DIST_DIR:=$PACKAGE_DIR/dist}
-BUILD_DIR=$SOURCE_DIR/dist
+BUILD_DIR=$SOURCE_DIR/build
 mkdir -p $BUILD_DIR $DIST_DIR
-
-
-# set the current version.  This will inject the version into the code, if 
-# needed.
-#
-(cd $PACKAGE_DIR ./scripts/setversion.sh)
 
 # don't reset the version unnecessarily as it may have been done by makedist
 # 
@@ -136,7 +117,7 @@ vers4fn=`echo $version | perl -pe 's#[/ \t]+#_#g'`
 
 echo '#########################'
 echo '#'
-echo "# Building ${DISTNAMES[0]}"...
+echo "# Building $DISTNAME"...
 echo '#'
 echo '#########################'
 
@@ -145,26 +126,23 @@ installdir=$BUILD_DIR/npsbroker
 set -x
 mkdir -p $installdir
 
-cp $PACKAGE_DIR/python/nps_server/nps_broker.py $installdir/nps_broker.py
+cp $SOURCE_DIR/nps_server/nps_broker.py $installdir/nps_broker.py
 
-# ENTER COMMANDS for creating the dependency file(s)
+# #Is this needed?  Eventually, for documentation purposes
 #
 # A dependency file should be called DISTNAME-${version}_dep.json
-mkdir -p $DIST_DIR
-if [ -n "$PYTHONPATH" ]; then
-    export PYTHONPATH=$installdir/lib/python:$PYTHONPATH
-else
-    export PYTHONPATH=$installdir/lib/python
-fi
+# if [ -n "$PYTHONPATH" ]; then
+#     export PYTHONPATH=$installdir/lib/python:$PYTHONPATH
+# else
+#     export PYTHONPATH=$installdir/lib/python
+# fi
+#
+# $execdir/record_python_deps.py $DISTNAME $version \
+#                         > $DIST_DIR/$DISTNAME-${vers4fn}_dep.json
 
-# #Is this needed?
-# $execdir/record_python_deps.py ${DISTNAMES[0]} $version \
-#                         > $DIST_DIR/${DISTNAMES[0]}-${vers4fn}_dep.json
-
-echo "bundle creation"
 # Bundle the distribution
-(cd $BUILD_DIR && zip -qr $DIST_DIR/${DISTNAMES[0]}-${vers4fn}.zip npsbroker)
+(cd $BUILD_DIR && zip -qr $DIST_DIR/$DISTNAME-${vers4fn}.zip npsbroker)
 
 set +x
 echo Created distribution in dist directory: 
-echo ${DISTNAMES[0]}-${vers4fn}.zip
+echo $DISTNAME-${vers4fn}.zip


### PR DESCRIPTION
This PR further cleans up the build scripts with a particular aim to support Docker-based builds within the NIST firewall.  (See docker/cacerts/README.md for details.)  This PR provides a means for injecting extra certificate authority (CA) certificates used by the local firewalled environment into the Docker container used to build this software.