### PR TITLE
Fix use of NPS broker service to display records under review

### DIFF
--- a/midas-portal/src/app/components/landing/landing.component.html
+++ b/midas-portal/src/app/components/landing/landing.component.html
@@ -80,7 +80,7 @@
       </div>
       <div class="col-lg-6 col-md-12 col-sm-12">
         <div class="table-dashboard">
-          <app-review-list [authToken]="authToken"></app-review-list>
+          <app-review-list [authToken]="authToken" [userId]="userId"></app-review-list>
           </div>
       </div>
       <div class="col-lg-6 col-md-12 col-sm-12">

--- a/midas-portal/src/app/components/tables/review-list/review-list.component.ts
+++ b/midas-portal/src/app/components/tables/review-list/review-list.component.ts
@@ -17,6 +17,7 @@ import { ConfigurationService } from 'oarng';
 export class ReviewListComponent implements OnInit {
   @ViewChild('reviewtable') reviewTable: Table;
   @Input() authToken: string|null = null;
+  @Input() userId: string|undefined|null = null;
   faUpRightAndDownLeftFromCenter=faUpRightAndDownLeftFromCenter;
   faBell=faBell;
   faListCheck=faUsersViewfinder;
@@ -37,7 +38,11 @@ export class ReviewListComponent implements OnInit {
   ngOnInit() {
       let config = this.configSvc.getConfig()
       this.NPSAPI = config['NPSAPI'];
+      if (! this.NPSAPI.endsWith('/'))
+          this.NPSAPI += '/';
       this.npsUI = config['npsUI'];
+      if (! this.npsUI.endsWith('/'))
+          this.npsUI += '/';
 
       this.statuses = [
           { label: 'Pending', value: 'Pending' },
@@ -50,8 +55,8 @@ export class ReviewListComponent implements OnInit {
    * update the state of this component as the result of changes in its parent
    */
   ngOnChanges(changes: SimpleChanges) {
-      if (this.authToken)
-          this.fetchRecords(this.NPSAPI);
+      if (this.authToken && this.userId)
+          this.fetchRecords(this.NPSAPI+this.userId);
   }
 
   /**
@@ -60,7 +65,7 @@ export class ReviewListComponent implements OnInit {
    * @returns string that is the link to the npsui interface of the dap
    */
   linkto(item:string){
-    return this.npsUI.concat('/Dataset/DataSetDetails?id=').concat(item.toString())
+    return this.npsUI.concat('Dataset/DataSetDetails?id=').concat(item.toString())
   }
 
 /**


### PR DESCRIPTION
The portal uses the NPS broker service to populate the "My Reviews" table.  Queries sent to the service were missing the required user identifier parameter.  This PR passes the user ID (along with the authentication token) from the `LandingComponent` (where it is retrieved from the authentication service) to the `ReviewListComponent` where it can be used to form the NPS broker query.