### PR TITLE
 fix search : extend to divisionName and groupName

### DIFF
--- a/midas-portal/src/app/models/dashboard.ts
+++ b/midas-portal/src/app/models/dashboard.ts
@@ -23,6 +23,7 @@ export interface Dap {
     location: string;
     type?: string;
     organizationUnit?: string;
+    orgNames?: string[];
     keywords?: string[];
     dataCategories?: string[];
     authors?: string[];
@@ -42,6 +43,7 @@ export interface Dmp {
     status?: string;
     hasPublication?: boolean;
     organizationUnit?: string;
+    orgNames?: string[];
     keywords?: string[];
     fundingType?: string;
     fundingNumber?: string;

--- a/midas-portal/src/app/pages/search/search.component.ts
+++ b/midas-portal/src/app/pages/search/search.component.ts
@@ -44,6 +44,7 @@ export interface Dmp {
   status?: string | undefined;
   hasPublication?: boolean;
   organizationUnit?: string;
+  orgNames?: string[];
   keywords?: string[];
 }
 

--- a/midas-portal/src/app/services/data.service.ts
+++ b/midas-portal/src/app/services/data.service.ts
@@ -213,6 +213,9 @@ export class DataService {
     owner: raw.owner,
     primaryContact,
     organizationUnit: raw.data?.organizations?.[0]?.ouName || '',
+    orgNames: (raw.data?.organizations as any[] || []).flatMap((o: any) =>
+      [o.ouName, o.divisionName, o.groupName].filter(Boolean)
+    ),
     modifiedDate: new Date(raw.status.modifiedDate),
     createdDate: raw.status.createdDate ? new Date(raw.status.createdDate) : undefined,
     startDate: raw.data?.startDate || '',
@@ -248,6 +251,9 @@ export class DataService {
       status: raw.status.state,
       location: raw.file_space?.location || '',
       organizationUnit: raw.data?.organizations?.[0]?.ouName || '',
+      orgNames: (raw.data?.organizations as any[] || []).flatMap((o: any) =>
+        [o.ouName, o.divisionName, o.groupName].filter(Boolean)
+      ),
       keywords: raw.data?.keywords || [],
       dataCategories: raw.data?.dataCategories || [],
       authors,

--- a/midas-portal/src/app/services/search-filter.service.spec.ts
+++ b/midas-portal/src/app/services/search-filter.service.spec.ts
@@ -1,6 +1,33 @@
 import { TestBed } from '@angular/core/testing';
+import { SearchFilterService, FilterCriteria } from './search-filter.service';
 
-import { SearchFilterService } from './search-filter.service';
+const BASE_CRITERIA: FilterCriteria = {
+  query: '',
+  keywords: [],
+  types: [],
+  statuses: [],
+  hasPublication: false,
+  dateFilterType: 'between',
+};
+
+const makeDmp = (overrides: any = {}) => ({
+  id: 'mdm1:0001',
+  name: 'Test DMP',
+  owner: 'TestId',
+  primaryContact: 'Martin Chiang',
+  organizationUnit: 'Material Measurement Laboratory',
+  orgNames: [
+    'Material Measurement Laboratory',
+    'Biosystems and Biomaterials Division',
+    'Biomaterials Group',
+  ],
+  type: 'dmp',
+  status: 'edit',
+  hasPublication: false,
+  keywords: ['testd'],
+  modifiedDate: new Date('2026-03-24'),
+  ...overrides,
+});
 
 describe('SearchFilterService', () => {
   let service: SearchFilterService;
@@ -12,5 +39,194 @@ describe('SearchFilterService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('text search', () => {
+    it('finds record by name', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, query: 'Test DMP' }
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('finds record by primary contact', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, query: 'Martin' }
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('finds record by ouName (top-level org)', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, query: 'Material Measurement' }
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('finds record by divisionName', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, query: 'Biosystems and Biomaterials Division' }
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('finds record by groupName', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, query: 'Biomaterials Group' }
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('finds record by partial groupName', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, query: 'Biomaterials' }
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('does not find record when query matches nothing', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, query: 'no match xyz' }
+      );
+      expect(result).toHaveLength(0);
+    });
+
+    it('returns all records when query is empty', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp(), makeDmp({ id: 'mdm1:0002', name: 'Other DMP' })],
+        { ...BASE_CRITERIA, query: '' }
+      );
+      expect(result).toHaveLength(2);
+    });
+
+    it('handles record with no orgNames gracefully', () => {
+      const dmp = makeDmp({ orgNames: undefined });
+      const result = service.filterDmpOrDapList(
+        [dmp],
+        { ...BASE_CRITERIA, query: 'Biomaterials' }
+      );
+      expect(result).toHaveLength(0);
+    });
+
+    it('searches across multiple organizations in orgNames', () => {
+      const dmp = makeDmp({
+        orgNames: [
+          'Material Measurement Laboratory',
+          'Biosystems and Biomaterials Division',
+          'Biomaterials Group',
+          'Information Technology Laboratory',
+          'Software and Systems Division',
+          'Applied Software Group',
+        ],
+      });
+      const result = service.filterDmpOrDapList(
+        [dmp],
+        { ...BASE_CRITERIA, query: 'Applied Software' }
+      );
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('org unit filter (exact match)', () => {
+    it('matches when orgUnit equals organizationUnit exactly', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, orgUnit: 'Material Measurement Laboratory' }
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('matches by divisionName via orgUnit filter', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, orgUnit: 'Biosystems and Biomaterials Division' }
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('matches by groupName via orgUnit filter', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, orgUnit: 'Biomaterials Group' }
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('strips org number suffix from orgUnit filter value', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, orgUnit: 'Biosystems and Biomaterials Division (644)' }
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('does not match a record whose orgNames do not include the filter value', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, orgUnit: 'Some Other Division' }
+      );
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('keyword filter', () => {
+    it('finds record matching a keyword', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, keywords: ['testd'] }
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('excludes record not matching a keyword', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, keywords: ['nope'] }
+      );
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('type filter', () => {
+    it('finds dmp when type filter includes dmp', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, types: ['dmp'] }
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('excludes dmp when type filter is dap only', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, types: ['dap'] }
+      );
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('status filter', () => {
+    it('finds record matching status', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, statuses: ['edit'] }
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('excludes record not matching status', () => {
+      const result = service.filterDmpOrDapList(
+        [makeDmp()],
+        { ...BASE_CRITERIA, statuses: ['published'] }
+      );
+      expect(result).toHaveLength(0);
+    });
   });
 });

--- a/midas-portal/src/app/services/search-filter.service.ts
+++ b/midas-portal/src/app/services/search-filter.service.ts
@@ -42,16 +42,13 @@ export class SearchFilterService {
   const kws = c.keywords.map(kw => normalize(kw));
   const orgUnitCriteria = normalizeOrgUnit(c.orgUnit || '');
   const ownerCriteria = normalizeOwner(c.owner || '');
-  console.log('criteria', c);
 
   return list.filter(item => {
-    // For fields that only exist on Dmp, use optional chaining or fallback
     const name = normalize((item as any).name);
     const primaryContact = normalize((item as any).primaryContact);
     const organizationUnit = normalize((item as any).organizationUnit);
     const owner = (item as any).owner?.toLowerCase() || '';
     const type = (item as any).type || '';
-    console.log('type', type);
     const status = (item as any).status || '';
     const hasPublication = (item as any).hasPublication;
     const keywords = (item as any).keywords || [];
@@ -60,10 +57,13 @@ export class SearchFilterService {
       : new Date((item as any).modifiedDate);
 
     // 1) text search
+    const orgNames: string[] = (item as any).orgNames || [];
     const textMatch =
+      !q ||
       name.includes(q) ||
       primaryContact.includes(q) ||
-      organizationUnit.includes(q);
+      organizationUnit.includes(q) ||
+      orgNames.some(n => n.toLowerCase().includes(q));
 
     // 2) keywords
     const keywordMatch =
@@ -72,8 +72,11 @@ export class SearchFilterService {
         (keywords || []).some((dk: string) => dk.toLowerCase().includes(kw))
       );
 
-    // 3) org unit
-    const orgMatch = !orgUnitCriteria || organizationUnit === orgUnitCriteria;
+    // 3) org unit — check ouName and all sub-levels (division, group)
+    const orgNamesNormalized = orgNames.map(n => normalizeOrgUnit(n));
+    const orgMatch = !orgUnitCriteria ||
+      organizationUnit === orgUnitCriteria ||
+      orgNamesNormalized.some(n => n === orgUnitCriteria);
 
     // 4) owner
     const ownerMatch = !ownerCriteria || 


### PR DESCRIPTION
Fixes search on the Search page so that records can be found by any level of the NIST organization hierarchy — lab (ouName), division (divisionName), and group (groupName) — instead of only the top-level lab name.