### PR TITLE
Widget default sizing issue - Stale  behaviour

### DIFF
--- a/midas-portal/src/app/services/dashboard.service.spec.ts
+++ b/midas-portal/src/app/services/dashboard.service.spec.ts
@@ -1,42 +1,115 @@
 import { TestBed } from '@angular/core/testing';
-import { signal } from '@angular/core';
 import { DashboardService } from './dashboard.service';
+
+const VERSIONED_WIDGETS = [
+  { id: 5, label: 'DMP Table', rows: 4, columns: 6, backgroundColor: 'red', textColor: 'blue' },
+  { id: 6, label: 'DAP Table', rows: 4, columns: 6, backgroundColor: 'red', textColor: 'blue' },
+];
 
 describe('DashboardService', () => {
   let service: DashboardService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [DashboardService]
-    });
-    service = TestBed.inject(DashboardService);
+    localStorage.clear();
   });
 
+  const createService = () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({ providers: [DashboardService] });
+    service = TestBed.inject(DashboardService);
+  };
+
   it('should be created', () => {
+    createService();
     expect(service).toBeTruthy();
   });
 
-  it('should have initial default widgets', () => {
-    expect(service.addedWidgets().length).toBe(4);
-    expect(service.widgetsToAdd().length).toBe(4); // Changed from 0 to 4
-    
-    // Test that the default widgets have expected properties
-    const addedWidgets = service.addedWidgets();
-    expect(addedWidgets[0].label).toBe('DMP Table');
-    expect(addedWidgets[1].label).toBe('DAP Table');
-    expect(addedWidgets[2].label).toBe('Reviews Table');
-    expect(addedWidgets[3].label).toBe('Files Table');
+  describe('new user (no localStorage)', () => {
+    it('loads 4 default table widgets from the registry', () => {
+      createService();
+      expect(service.addedWidgets().length).toBe(4);
+      expect(service.addedWidgets()[0].label).toBe('DMP Table');
+      expect(service.addedWidgets()[1].label).toBe('DAP Table');
+      expect(service.addedWidgets()[2].label).toBe('Reviews Table');
+      expect(service.addedWidgets()[3].label).toBe('Files Table');
+    });
+
+    it('loads registry default columns and rows', () => {
+      createService();
+      const dmp = service.addedWidgets()[0];
+      expect(dmp.columns).toBe(4);
+      expect(dmp.rows).toBe(3);
+    });
+  });
+
+  describe('existing user with versioned localStorage (user customizations)', () => {
+    beforeEach(() => {
+      localStorage.setItem('dashboardWidgets', JSON.stringify(VERSIONED_WIDGETS));
+      localStorage.setItem('dashboardSchemaVersion', '2');
+    });
+
+    it('preserves user customized columns and rows', () => {
+      createService();
+      expect(service.addedWidgets()[0].columns).toBe(6);
+      expect(service.addedWidgets()[0].rows).toBe(4);
+    });
+
+    it('preserves the number of widgets the user had', () => {
+      createService();
+      expect(service.addedWidgets().length).toBe(2);
+    });
+
+    it('re-attaches the component class from the registry', () => {
+      createService();
+      expect(service.addedWidgets()[0].content).toBeDefined();
+    });
+  });
+
+  describe('existing user with stale pre-versioning localStorage (no version key)', () => {
+    beforeEach(() => {
+      localStorage.setItem('dashboardWidgets', JSON.stringify(VERSIONED_WIDGETS));
+      // No dashboardSchemaVersion key — simulates old data before versioning
+    });
+
+    it('ignores stale data and resets to registry defaults', () => {
+      createService();
+      expect(service.addedWidgets().length).toBe(4);
+    });
+
+    it('applies registry default columns after reset', () => {
+      createService();
+      expect(service.addedWidgets()[0].columns).toBe(4);
+      expect(service.addedWidgets()[0].rows).toBe(3);
+    });
+
+    it('removes the stale dashboardWidgets key on reset', () => {
+      createService();
+      // The service clears localStorage.dashboardWidgets before setting new defaults
+      // so the raw JSON no longer holds the old stale columns: 6 values
+      const raw = localStorage.getItem('dashboardWidgets');
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        expect(parsed[0].columns).not.toBe(6);
+      }
+    });
+  });
+
+  describe('corrupted localStorage', () => {
+    beforeEach(() => {
+      localStorage.setItem('dashboardWidgets', 'not valid json {{{');
+      localStorage.setItem('dashboardSchemaVersion', '2');
+    });
+
+    it('falls back to registry defaults when JSON is invalid', () => {
+      createService();
+      expect(service.addedWidgets().length).toBe(4);
+      expect(service.addedWidgets()[0].label).toBe('DMP Table');
+    });
   });
 
   it('should update widget position', () => {
-    const sourceIndex = 0;
-    const destinationIndex = 2;
-    
-    const originalWidgets = [...service.addedWidgets()];
-    service.updateWidgetPosition(sourceIndex, destinationIndex);
-    
-    // Verify the widgets were reordered
-    const updatedWidgets = service.addedWidgets();
-    expect(updatedWidgets.length).toBe(4);
+    createService();
+    service.updateWidgetPosition(0, 2);
+    expect(service.addedWidgets().length).toBe(4);
   });
 });

--- a/midas-portal/src/app/services/dashboard.service.ts
+++ b/midas-portal/src/app/services/dashboard.service.ts
@@ -12,6 +12,10 @@ export interface UserDetails {
   Group: string;
 }
 
+// Bump this when widget registry defaults change (rows, columns, colors).
+// Forces all users to get fresh defaults, discarding stale localStorage data.
+const DASHBOARD_SCHEMA_VERSION = 2;
+
 @Injectable()
 export class DashboardService {
   /** All available widgets */
@@ -38,6 +42,7 @@ export class DashboardService {
     const widgetsWithoutContent: Partial<Widget>[] = this.addedWidgets().map(w => ({ ...w }));
     widgetsWithoutContent.forEach(w => delete w.content);
     localStorage.setItem('dashboardWidgets', JSON.stringify(widgetsWithoutContent));
+    localStorage.setItem('dashboardSchemaVersion', String(DASHBOARD_SCHEMA_VERSION));
   })
 
   /** Read previously saved widgets and restore their content preferences */
@@ -60,7 +65,11 @@ export class DashboardService {
 
   private _loadPersistedOrDefaultWidgets() {
     const json = localStorage.getItem('dashboardWidgets');
-    if (json) {
+    const hasVersion = localStorage.getItem('dashboardSchemaVersion') !== null;
+
+    // If data exists AND was saved with the versioned system, always respect it.
+    // User customizations (columns, rows, colors) are never overwritten by registry changes.
+    if (json && hasVersion) {
       try {
         const saved = JSON.parse(json) as Widget[];
         for (const w of saved) {
@@ -73,7 +82,10 @@ export class DashboardService {
         console.warn('Failed to parse persisted dashboardWidgets');
       }
     }
-    // No saved widgets: use defaults
+
+    // No data, or pre-versioning stale data: reset to current registry defaults.
+    // This runs once for old users, then never again once the version key is written.
+    localStorage.removeItem('dashboardWidgets');
     const defaults = this.widgets().filter(w => this.DEFAULT_WIDGET_IDS.includes(w.id));
     this.addedWidgets.set(defaults);
   }


### PR DESCRIPTION
Fix dashboard widgets not picking up updated default rows/columns values from the registry.

Added a dashboardSchemaVersion marker to localStorage. On load:

No version key (stale pre-versioning data) → cleared, registry defaults applied once
Version key present → user data trusted and preserved as-is
User customizations (columns, rows, colors) are never overwritten by registry changes. Registry defaults only apply to new users or users being migrated from pre-versioning data.